### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,33 +6,33 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-TTVCNL4040		KEYWORD1
+TTVCNL4040	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-isConnected		KEYWORD2
+isConnected	KEYWORD2
 isALSEnabled	KEYWORD2
-isPSEnabled		KEYWORD2
-enableALS			KEYWORD2
+isPSEnabled	KEYWORD2
+enableALS	KEYWORD2
 setALSIntegrationTime	KEYWORD2
-readALS				KEYWORD2
-readWhite			KEYWORD2
-readLux				KEYWORD2
-disableALS		KEYWORD2
-enablePS			KEYWORD2
-readPS				KEYWORD2
-disablePS			KEYWORD2
-readCommandRegister		KEYWORD2
+readALS	KEYWORD2
+readWhite	KEYWORD2
+readLux	KEYWORD2
+disableALS	KEYWORD2
+enablePS	KEYWORD2
+readPS	KEYWORD2
+disablePS	KEYWORD2
+readCommandRegister	KEYWORD2
 writeCommandRegister	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-IR_PWR_50MA		LITERAL1
-IR_PWR_75MA		LITERAL1
+IR_PWR_50MA	LITERAL1
+IR_PWR_75MA	LITERAL1
 IR_PWR_100MA	LITERAL1
 IR_PWR_120MA	LITERAL1
 IR_PWR_140MA	LITERAL1
@@ -40,7 +40,7 @@ IR_PWR_160MA	LITERAL1
 IR_PWR_180MA	LITERAL1
 IR_PWR_200MA	LITERAL1
 
-ALS_IT_80MS		LITERAL1
+ALS_IT_80MS	LITERAL1
 ALS_IT_160MS	LITERAL1
 ALS_IT_320MS	LITERAL1
 ALS_IT_640MS	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords